### PR TITLE
add fuse:melt_async/1

### DIFF
--- a/src/fuse.erl
+++ b/src/fuse.erl
@@ -3,31 +3,21 @@
 -module(fuse).
 
 -ifdef(PULSE).
+
 -include_lib("pulse_otp/include/pulse_otp.hrl").
+
 -endif.
 
--export([
-    ask/2,
-    install/2,
-    melt/1,
-    remove/1,
-    reset/1,
-    run/3
-]).
-
--export([
-    circuit_enable/1,
-    circuit_disable/1
-]).
+-export([ask/2, install/2, melt/1, melt_async/1, remove/1, reset/1, run/3]).
+-export([circuit_enable/1, circuit_disable/1]).
 
 -type fuse_context() :: sync | async_dirty.
 -type fault_rate() :: float().
 -type fuse_strategy() ::
-    {standard, non_neg_integer(), pos_integer()}
-    | {fault_injection, fault_rate(), pos_integer(), pos_integer()}.
+  {standard, non_neg_integer(), pos_integer()} |
+  {fault_injection, fault_rate(), pos_integer(), pos_integer()}.
 -type fuse_refresh() :: {reset, pos_integer()}.
--type fuse_options() ::
-    {fuse_strategy(), fuse_refresh()}.
+-type fuse_options() :: {fuse_strategy(), fuse_refresh()}.
 
 -export_type([fuse_context/0, fuse_options/0]).
 
@@ -37,13 +27,12 @@
 %% @end
 %% install/2
 -spec install(Name, Options) -> ok | reset | {error, Reason}
-    when
-      Name :: term(),
-      Options :: fuse_options(),
-      Reason :: any().
+  when Name :: term(),
+       Options :: fuse_options(),
+       Reason :: any().
 install(Name, Options) ->
-    options_ok(Options),
-    fuse_server:install(Name, Options).
+  options_ok(Options),
+  fuse_server:install(Name, Options).
 
 %% @doc Administratively disables a circuit.
 %% <p>This function is intended to be used administratively, when you want to break the fuse
@@ -53,10 +42,9 @@ install(Name, Options) ->
 %% <p>Disabling a circuit dominates every other operation, except `remove/1'.</p>
 %% @end.
 %% circuit_disable/1
--spec circuit_disable(Name) -> ok
-   when Name :: term().
+-spec circuit_disable(Name) -> ok when Name :: term().
 circuit_disable(Name) ->
-    fuse_server:circuit(Name, disable).
+  fuse_server:circuit(Name, disable).
 
 %% @doc Administratively (re-)enables a fuse.
 %% <p>This call is used to reenable a disabled circuit again. Always returns ok and is idempotent.</p>
@@ -64,71 +52,72 @@ circuit_disable(Name) ->
 %% to resume normal operation of the fuse.</p>
 %% @end
 %% circuit_enable/1
--spec circuit_enable(Name) -> ok
-  when Name :: term().
+-spec circuit_enable(Name) -> ok when Name :: term().
 circuit_enable(Name) ->
-    fuse_server:circuit(Name, enable).
+  fuse_server:circuit(Name, enable).
 
 %% @doc Runs a thunk under a given fuse.
 %% <p>Calling `run(Name, Func)' will run `Func' protected by the fuse `Name'.</p>
 %% @end
 %% run/3
--spec run(Name, fun (() -> {ok, Result} | {melt, Result}), fuse_context() ) -> {ok, Result} | blown | {error, not_found}
-    when
-      Name :: term(),
-      Result :: any().
-run(Name, Func, Context) -> fuse_server:run(Name, Func, Context).
-
+-spec run(Name, fun(() -> {ok, Result} | {melt, Result}), fuse_context()) ->
+           {ok, Result} | blown | {error, not_found}
+  when Name :: term(),
+       Result :: any().
+run(Name, Func, Context) ->
+  fuse_server:run(Name, Func, Context).
 
 %% @doc Queries the state of a fuse.
 %% <p>Given `ask(N)' we ask the fuse state for the name `N'. Returns the fuse state, either `ok' or `blown'.
 %% If there is no such fuse, returns `{error, not_found}'.</p>
 %% @end
 %% ask/2
--spec ask(Name, fuse_context()) -> ok | blown | {error, not_found}
-  when Name :: term().
-ask(Name, Context) -> fuse_server:ask(Name, Context).
+-spec ask(Name, fuse_context()) -> ok | blown | {error, not_found} when Name :: term().
+ask(Name, Context) ->
+  fuse_server:ask(Name, Context).
 
 %% @doc Resets a fuse.
 %% <p>Given `reset(N)' this resets the fuse under the name `N'. The fuse will be unbroken with no melts.</p>
 %% @end
 %% reset/1
--spec reset(Name) -> ok | {error, not_found}
-  when Name :: term().
+-spec reset(Name) -> ok | {error, not_found} when Name :: term().
 reset(Name) ->
-    fuse_server:reset(Name).
+  fuse_server:reset(Name).
 
 %% @doc Melts a fuse a little bit.
 %% <p>A call to `melt(N)' will melt fuse `N'. This call always returns `ok' and it is currently implemented synchronously.</p>
 %% @end
 %% melt/1
--spec melt(Name) -> ok
-  when Name :: term().
+-spec melt(Name) -> ok when Name :: term().
 melt(Name) ->
-    fuse_server:melt(Name).
+  fuse_server:melt(Name).
+
+%% @doc Asynchronously melts a fuse a little bit.
+%% <p>A call to `melt(N)' will melt fuse `N'. This call always returns `ok' and it is currently implemented asynchronously.</p>
+%% @end
+%% melt/1
+-spec melt_async(Name) -> ok when Name :: term().
+melt_async(Name) ->
+  fuse_server:melt_async(Name).
 
 %% @doc Removes a fuse.
 %% <p>Given `remove(N)' this removes the fuse under the name `N'. This fuse will no longer exist.</p>
 %% @end
 %% remove/1
--spec remove(Name) -> ok
-  when Name :: term().
+-spec remove(Name) -> ok when Name :: term().
 remove(Name) ->
-    fuse_server:remove(Name).
+  fuse_server:remove(Name).
 
 %% Internal functions
 %% -----------------------
 
 options_ok({{standard, MaxR, MaxT}, {reset, Time}})
-    when
-      is_integer(MaxR), MaxR >= 0,
-      is_integer(MaxT), MaxT >= 0,
-      is_integer(Time), Time >= 0 -> ok;
+  when is_integer(MaxR), MaxR >= 0, is_integer(MaxT), MaxT >= 0, is_integer(Time),
+       Time >= 0 ->
+  ok;
 options_ok({{fault_injection, Rate, MaxR, MaxT}, {reset, Time}})
-    when
-      is_integer(MaxR), MaxR > 0,
-      is_integer(MaxT), MaxT >= 0,
-      is_integer(Time), Time >= 0,
-      is_float(Rate), 0.0 < Rate, Rate =< 1.0 -> ok;
+  when is_integer(MaxR), MaxR > 0, is_integer(MaxT), MaxT >= 0, is_integer(Time), Time >= 0,
+       is_float(Rate), 0.0 < Rate, Rate =< 1.0 ->
+  ok;
 options_ok(_) ->
-    error(badarg).
+  error(badarg).

--- a/src/fuse_server.erl
+++ b/src/fuse_server.erl
@@ -1,49 +1,39 @@
 %%% @doc Runs the fuse server in the system
 %%% @private
 -module(fuse_server).
+
 -behaviour(gen_server).
 
 -ifdef(PULSE).
--include_lib("pulse_otp/include/pulse_otp.hrl").
--endif.
 
+-include_lib("pulse_otp/include/pulse_otp.hrl").
+
+-endif.
 
 %% Lifetime API
 -export([start_link/0]).
-
 %% Operational API
--export([
-    ask/2,
-    install/2,
-    melt/1,
-    remove/1,
-    reset/1,
-    run/3]).
-
+-export([ask/2, install/2, melt/1, melt_async/1, remove/1, reset/1, run/3]).
 %% Administrative API
--export([
-    circuit/2
-]).
-
+-export([circuit/2]).
 %% Callbacks
--export([code_change/3, handle_call/3, handle_cast/2, handle_info/2, init/1, terminate/2]).
-
+-export([code_change/3, handle_call/3, handle_cast/2, handle_info/2, init/1,
+         terminate/2]).
 %% Private
 -export([sync/0, q_melts/0]).
 
 -define(TAB, fuse_state).
 
--record(state, { fuses = [] }).
--record(fuse, {
-    name :: atom(),
-    intensity :: integer(),
-    period :: integer(),
-    heal_time :: integer(),
-    melt_history = [],
-    ty = ok :: 'ok' | {gradual, float()},
-    timer_ref = none,
-    enabled = true
-}).
+-record(state, {fuses = []}).
+-record(fuse,
+        {name :: atom(),
+         intensity :: integer(),
+         period :: integer(),
+         heal_time :: integer(),
+         melt_history = [],
+         ty = ok :: ok | {gradual, float()},
+         timer_ref = none,
+         enabled = true}).
 
 %% -- API -----------------------------------------------------
 
@@ -52,7 +42,7 @@
 %% This is assumed to be called by (@see fuse_sup). The `Timing' parameter controls how the system manages timing.
 %% @end
 start_link() ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+  gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 %% ------
 %% @doc install/2 installs a new fuse into the running system
@@ -60,299 +50,334 @@ start_link() ->
 %% We assume `Opts' are already in the right verified and validated format.
 %% @end
 install(Name, Opts) ->
-    %% Assume options are already verified
-    Fuse = init_state(Name, Opts),
-    gen_server:call(?MODULE, {install, Fuse}).
+  %% Assume options are already verified
+  Fuse = init_state(Name, Opts),
+  gen_server:call(?MODULE, {install, Fuse}).
 
 %% @doc ask/2 asks about the current given fuse state in a given context setting
 %% The documentation is (@see fuse:ask/1)
 %% @end
 -spec ask(atom(), fuse:fuse_context()) -> ok | blown | {error, not_found}.
-ask(Name, sync) -> gen_server:call(?MODULE, {ask, Name});
-ask(Name, async_dirty) -> ask_(Name).
+ask(Name, sync) ->
+  gen_server:call(?MODULE, {ask, Name});
+ask(Name, async_dirty) ->
+  ask_(Name).
 
 %% ask_/1 is the real ask function.
 ask_(Name) ->
-    StatsPlugin = application:get_env(fuse, stats_plugin, fuse_stats_ets),
-    try ets:lookup_element(?TAB, Name, 2) of
-        ok ->
-          _ = StatsPlugin:increment(Name, ok),
-          ok;
-        blown ->
-          _ = StatsPlugin:increment(Name, blown),
+  StatsPlugin = application:get_env(fuse, stats_plugin, fuse_stats_ets),
+  try ets:lookup_element(?TAB, Name, 2) of
+    ok ->
+      _ = StatsPlugin:increment(Name, ok),
+      ok;
+    blown ->
+      _ = StatsPlugin:increment(Name, blown),
+      blown;
+    {gradual, Rate} ->
+      case fuse_rand:uniform() of
+        K when K < Rate ->
           blown;
-        {gradual, Rate} ->
-            case fuse_rand:uniform() of
-                K when K < Rate ->
-                    blown;
-                _ ->
-                    ok
-            end
-    catch
-        error:badarg ->
-            {error, not_found}
-    end.
+        _ ->
+          ok
+      end
+  catch
+    error:badarg ->
+      {error, not_found}
+  end.
 
 %% @doc reset/1 resets the fuse
 %% The documentation is (@see fuse:reset/1)
 %% @end
 -spec reset(atom()) -> ok | {error, not_found}.
 reset(Name) ->
-    gen_server:call(?MODULE, {reset, Name}).
+  gen_server:call(?MODULE, {reset, Name}).
 
 %% @doc circuit/2 is used to manually override the fuse state
 %% @end
 -spec circuit(atom(), enable | disable) -> ok.
 circuit(Name, Switch) ->
-    gen_server:call(?MODULE, {circuit, Name, Switch}).
+  gen_server:call(?MODULE, {circuit, Name, Switch}).
 
 %% @doc melt/2 melts the fuse at a given point in time
 %% For documentation, (@see fuse:melt/2)
 %% @end
--spec melt(Name) -> ok
-    when Name :: atom().
+-spec melt(Name) -> ok when Name :: atom().
 melt(Name) ->
-    gen_server:call(?MODULE, {melt, Name}).
+  gen_server:call(?MODULE, {melt, Name}).
+
+%% @doc melt_async/2 melts the fuse at a given point in time
+%% For documentation, (@see fuse:melt/2)
+%% @end
+-spec melt_async(Name) -> ok when Name :: atom().
+melt_async(Name) ->
+  gen_server:cast(?MODULE, {melt, Name}).
 
 %% @doc remove/1 removes the fuse
 %% The documentation is (@see fuse:remove/1)
 %% @end
 -spec remove(atom()) -> ok | {error, not_found}.
 remove(Name) ->
-    gen_server:call(?MODULE, {remove, Name}).
+  gen_server:call(?MODULE, {remove, Name}).
 
 %% sync/0 syncs the server. For internal use only in tests
 %% @private
 sync() ->
-    gen_server:call(?MODULE, sync).
+  gen_server:call(?MODULE, sync).
 
 q_melts() ->
-    gen_server:call(?MODULE, q_melts).
+  gen_server:call(?MODULE, q_melts).
 
 %% run/3 runs a thunk under a given fuse in a given context
 %% @doc Documentation is (@see fuse:run/3)
 %% @end
 %% @private
 -spec run(Name, fun(() -> {ok, Result} | {melt, Result}), fuse:fuse_context()) ->
-    {ok, Result} | blown | {error, not_found}
-  when
-    Name :: atom(),
-    Result :: any().
-
+           {ok, Result} | blown | {error, not_found}
+  when Name :: atom(),
+       Result :: any().
 run(Name, Func, Context) ->
-    case ask(Name, Context) of
-        blown -> blown;
-        ok ->
-          case Func() of
-              {ok, Result} -> {ok, Result};
-              {melt, Result} ->
-                  melt(Name),
-                  {ok, Result}
-          end;
-        {error, Reason} ->
-          {error, Reason}
-    end.
+  case ask(Name, Context) of
+    blown ->
+      blown;
+    ok ->
+      case Func() of
+        {ok, Result} ->
+          {ok, Result};
+        {melt, Result} ->
+          melt(Name),
+          {ok, Result}
+      end;
+    {error, Reason} ->
+      {error, Reason}
+  end.
 
 %% -- CALLBACKS --------------------------------------------
 
 %% @private
 init([]) ->
-    _ = ets:new(?TAB, [named_table, protected, set, {read_concurrency, true}, {keypos, 1}]),
-    {ok, #state{ }}.
+  _ = ets:new(?TAB, [named_table, protected, set, {read_concurrency, true}, {keypos, 1}]),
+  {ok, #state{}}.
 
 %% @private
-handle_call({install, #fuse { name = Name } = F}, _From, #state { fuses = Fs } = State) ->
-        case lists:keytake(Name, #fuse.name, Fs) of
-            false ->
-                install_metrics(F),
-                fix(F),
-                {reply, ok, State#state { fuses = lists:keystore(Name, #fuse.name, Fs, F)}};
-            {value, OldFuse, _Otherfuses} ->
-                EF = F#fuse { enabled = OldFuse#fuse.enabled },
-                fix(EF),
-                _ = reset_timer(OldFuse), %% For effect only
-                %% Transplant the enabled-state from the old fuse
-                {reply, ok, State#state {
-                    fuses = lists:keystore(Name, #fuse.name, Fs, EF) }}
-        end;
+handle_call({install, #fuse{name = Name} = F}, _From, #state{fuses = Fs} = State) ->
+  case lists:keytake(Name, #fuse.name, Fs) of
+    false ->
+      install_metrics(F),
+      fix(F),
+      {reply, ok, State#state{fuses = lists:keystore(Name, #fuse.name, Fs, F)}};
+    {value, OldFuse, _Otherfuses} ->
+      EF = F#fuse{enabled = OldFuse#fuse.enabled},
+      fix(EF),
+      _ = reset_timer(OldFuse), %% For effect only
+      %% Transplant the enabled-state from the old fuse
+      {reply, ok, State#state{fuses = lists:keystore(Name, #fuse.name, Fs, EF)}}
+  end;
 handle_call({circuit, Name, Switch}, _From, State) ->
-    {Reply, State2} = handle_circuit(Name, Switch, State),
-    {reply, Reply, State2};
+  {Reply, State2} = handle_circuit(Name, Switch, State),
+  {reply, Reply, State2};
 handle_call({reset, Name}, _From, State) ->
-    {Reply, State2} = handle_reset(Name, State, reset),
-    {reply, Reply, State2};
+  {Reply, State2} = handle_reset(Name, State, reset),
+  {reply, Reply, State2};
 handle_call({remove, Name}, _From, State) ->
-    {Reply, State2} = handle_remove(Name, State),
-    {reply, Reply, State2};
+  {Reply, State2} = handle_remove(Name, State),
+  {reply, Reply, State2};
 handle_call({melt, Name}, _From, State) ->
-    Now = fuse_time:monotonic_time(),
-    {Res, State2} = with_fuse(Name, State, fun(F) -> add_restart(Now, F) end),
-    case Res of
-      ok ->
-            StatsPlugin = application:get_env(fuse, stats_plugin, fuse_stats_ets),
-            _ = StatsPlugin:increment(Name, melt),
-        {reply, ok, State2};
-      not_found -> {reply, ok, State2}
-    end;
+  handle_melt(Name, State, fun(NewState) -> {reply, ok, NewState} end);
 handle_call({ask, Name}, _F, State) ->
-    {reply, ask_(Name), State};
+  {reply, ask_(Name), State};
 handle_call(sync, _F, State) ->
-    {reply, ok, State};
-handle_call(q_melts, _From, #state { fuses = Fs } = State) ->
-        {reply, [{N, Ms} || #fuse { name = N, melt_history = Ms } <- Fs], State};
-handle_call(q_disabled, _From, #state { fuses = Fs } = State) ->
-    {reply, [Name || #fuse { name = Name, enabled = false } <- Fs], State};
+  {reply, ok, State};
+handle_call(q_melts, _From, #state{fuses = Fs} = State) ->
+  {reply, [{N, Ms} || #fuse{name = N, melt_history = Ms} <- Fs], State};
+handle_call(q_disabled, _From, #state{fuses = Fs} = State) ->
+  {reply, [Name || #fuse{name = Name, enabled = false} <- Fs], State};
 handle_call(_M, _F, State) ->
-    {reply, {error, unknown}, State}.
+  {reply, {error, unknown}, State}.
 
+handle_cast({melt, Name}, State) ->
+  handle_melt(Name, State, fun(NewState) -> {noreply, NewState} end);
 %% @private
 handle_cast(_M, State) ->
-    {noreply, State}.
+  {noreply, State}.
 
 %% @private
 handle_info({reset, Name}, State) ->
-    {_Reply, State2} = handle_reset(Name, State, timeout),
-    {noreply, State2};
+  {_Reply, State2} = handle_reset(Name, State, timeout),
+  {noreply, State2};
 handle_info(_M, State) ->
-    {noreply, State}.
+  {noreply, State}.
+
+handle_melt(Name, State, ReplyFun) ->
+  Now = fuse_time:monotonic_time(),
+  {Res, State2} = with_fuse(Name, State, fun(F) -> add_restart(Now, F) end),
+  case Res of
+    ok ->
+      StatsPlugin = application:get_env(fuse, stats_plugin, fuse_stats_ets),
+      _ = StatsPlugin:increment(Name, melt),
+      ReplyFun(State2);
+    not_found ->
+      ReplyFun(State2)
+  end.
 
 %% @private
 terminate(_Reason, _State) ->
-    ok.
+  ok.
 
 %% @private
 code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
+  {ok, State}.
 
 %%% Internal functions
 %%% ------
 
 handle_reset(Name, State, ResetType) ->
-    Reset = fun(#fuse { timer_ref = TRef } = F) ->
-            case ResetType of
-                reset ->
-                    fix(F),
-                    NewF = reset_timer(F),
-                    {ok, NewF#fuse { melt_history = [] }};
-                timeout when TRef /= none ->
-                    fix(F),
-                    NewF = reset_timer(F),
-                    {ok, NewF#fuse { melt_history = [], timer_ref = none }};
-                timeout when TRef == none ->
-                    %% No timer installed on this fuse, it is a async fluke
-                    {ok, F}
-            end
+  Reset =
+    fun(#fuse{timer_ref = TRef} = F) ->
+       case ResetType of
+         reset ->
+           fix(F),
+           NewF = reset_timer(F),
+           {ok, NewF#fuse{melt_history = []}};
+         timeout when TRef /= none ->
+           fix(F),
+           NewF = reset_timer(F),
+           {ok, NewF#fuse{melt_history = [], timer_ref = none}};
+         timeout when TRef == none ->
+           %% No timer installed on this fuse, it is a async fluke
+           {ok, F}
+       end
     end,
-    {Res, State2} = with_fuse(Name, State, Reset),
-    case Res of
-      ok -> {ok, State2};
-      not_found -> {{error, not_found}, State2}
-    end.
+  {Res, State2} = with_fuse(Name, State, Reset),
+  case Res of
+    ok ->
+      {ok, State2};
+    not_found ->
+      {{error, not_found}, State2}
+  end.
 
 handle_circuit(Name, Switch, State) ->
-    Fn = fun(#fuse { enabled = En } = F) ->
-        case Switch of
-            enable when En -> {ok, F};
-            enable ->
-                F1 = F#fuse { enabled = true },
-                fix(F1),
-                {ok, F1#fuse { melt_history = [] }};
-            disable when not En -> {ok, F};
-            disable ->
-                blow(F),
-                NewF = reset_timer(F),
-                {ok, NewF#fuse { enabled = false }}
-        end
+  Fn =
+    fun(#fuse{enabled = En} = F) ->
+       case Switch of
+         enable when En -> {ok, F};
+         enable ->
+           F1 = F#fuse{enabled = true},
+           fix(F1),
+           {ok, F1#fuse{melt_history = []}};
+         disable when not En -> {ok, F};
+         disable ->
+           blow(F),
+           NewF = reset_timer(F),
+           {ok, NewF#fuse{enabled = false}}
+       end
     end,
-    {Res, State2} = with_fuse(Name, State, Fn),
-    case Res of
-        ok -> {ok, State2};
-        not_found -> {{error, not_found}, State2}
-    end.
+  {Res, State2} = with_fuse(Name, State, Fn),
+  case Res of
+    ok ->
+      {ok, State2};
+    not_found ->
+      {{error, not_found}, State2}
+  end.
 
-handle_remove(Name, #state { fuses = Fs } = State) ->
-    case lists:keytake(Name, #fuse.name, Fs) of
-        false -> {{error, not_found}, State};
-        {value, F, OtherFs} ->
-            delete(F),
-            {ok, State#state { fuses = OtherFs }}
-    end.
+handle_remove(Name, #state{fuses = Fs} = State) ->
+  case lists:keytake(Name, #fuse.name, Fs) of
+    false ->
+      {{error, not_found}, State};
+    {value, F, OtherFs} ->
+      delete(F),
+      {ok, State#state{fuses = OtherFs}}
+  end.
 
 init_state(Name, {{fault_injection, Rate, MR, MT}, {reset, Reset}}) ->
-    init_state(Name, {gradual, Rate}, MR, MT, {reset, Reset});
+  init_state(Name, {gradual, Rate}, MR, MT, {reset, Reset});
 init_state(Name, {{standard, MR, MT}, {reset, Reset}}) ->
-    init_state(Name, ok, MR, MT, {reset, Reset}).
+  init_state(Name, ok, MR, MT, {reset, Reset}).
 
 init_state(Name, Ty, MR, MT, {reset, Reset}) ->
-    NativePeriod = fuse_time:convert_time_unit(MT, milli_seconds, native),
-    #fuse {
-      name = Name,
-      intensity = MR,
-      period = NativePeriod,
-      heal_time = Reset,
-      ty = Ty
-    }.
+  NativePeriod = fuse_time:convert_time_unit(MT, milli_seconds, native),
+  #fuse{name = Name,
+        intensity = MR,
+        period = NativePeriod,
+        heal_time = Reset,
+        ty = Ty}.
 
-with_fuse(Name, #state { fuses = Fs} = State, Fun) ->
-    case lists:keytake(Name, #fuse.name, Fs) of
-        false -> {not_found, State};
-        {value, F, OtherFs} ->
-            {R, FF} = Fun(F),
-            {R, State#state { fuses = [FF | OtherFs] }}
-    end.
+with_fuse(Name, #state{fuses = Fs} = State, Fun) ->
+  case lists:keytake(Name, #fuse.name, Fs) of
+    false ->
+      {not_found, State};
+    {value, F, OtherFs} ->
+      {R, FF} = Fun(F),
+      {R, State#state{fuses = [FF | OtherFs]}}
+  end.
 
-add_restart(Now, #fuse { intensity = I, period = Period, melt_history = R } = Fuse) ->
-    R1 = add_restart_([Now | R], Now, Period),
-    NewF = Fuse#fuse { melt_history = R1 },
-    case length(R1) of
-        CurI when CurI =< I ->
-            {ok, NewF};
-        _ ->
-            blow(NewF),
-            {ok, install_timer(NewF)}
-    end.
+add_restart(Now,
+            #fuse{intensity = I,
+                  period = Period,
+                  melt_history = R} =
+              Fuse) ->
+  R1 = add_restart_([Now | R], Now, Period),
+  NewF = Fuse#fuse{melt_history = R1},
+  case length(R1) of
+    CurI when CurI =< I ->
+      {ok, NewF};
+    _ ->
+      blow(NewF),
+      {ok, install_timer(NewF)}
+  end.
 
-add_restart_([R|Restarts], Now, Period) ->
-    case in_period(R, Now, Period) of
-        true -> [R|add_restart_(Restarts, Now, Period)];
-        false -> []
-    end;
-add_restart_([], _, _) -> [].
+add_restart_([R | Restarts], Now, Period) ->
+  case in_period(R, Now, Period) of
+    true ->
+      [R | add_restart_(Restarts, Now, Period)];
+    false ->
+      []
+  end;
+add_restart_([], _, _) ->
+  [].
 
-in_period(Time, Now, Period) when (Now - Time) >= Period -> false;
-in_period(_, _, _) -> true.
+in_period(Time, Now, Period) when Now - Time >= Period ->
+  false;
+in_period(_, _, _) ->
+  true.
 
 %% -- FUSE MANIPULATION ------------------
-blow(#fuse { enabled = false }) -> ok;
-blow(#fuse { name = Name }) ->
-    ets:insert(?TAB, {Name, blown}),
-    fuse_event:notify({Name, blown}).
+blow(#fuse{enabled = false}) ->
+  ok;
+blow(#fuse{name = Name}) ->
+  ets:insert(?TAB, {Name, blown}),
+  fuse_event:notify({Name, blown}).
 
-fix(#fuse { enabled = false }) -> ok;
-fix(#fuse { name = Name, ty = TY }) ->
-    ets:insert(?TAB, {Name, TY}),
-    fuse_event:notify({Name, TY}),
-    ok.
+fix(#fuse{enabled = false}) ->
+  ok;
+fix(#fuse{name = Name, ty = TY}) ->
+  ets:insert(?TAB, {Name, TY}),
+  fuse_event:notify({Name, TY}),
+  ok.
 
-delete(#fuse { name = Name }) ->
-    ets:delete(?TAB, Name),
-    fuse_event:notify({Name, removed}),
-    ok.
+delete(#fuse{name = Name}) ->
+  ets:delete(?TAB, Name),
+  fuse_event:notify({Name, removed}),
+  ok.
 
 %% -- TIMERS ----
-install_timer(#fuse { enabled = false } = F) -> F;
-install_timer(#fuse { name = Name, timer_ref = none, heal_time = HealTime } = F) ->
-    TRef = fuse_time:send_after(HealTime, self(), {reset, Name}),
-    F#fuse{ timer_ref = TRef };
+install_timer(#fuse{enabled = false} = F) ->
+  F;
+install_timer(#fuse{name = Name,
+                    timer_ref = none,
+                    heal_time = HealTime} =
+                F) ->
+  TRef = fuse_time:send_after(HealTime, self(), {reset, Name}),
+  F#fuse{timer_ref = TRef};
 install_timer(F) ->
-    F.
+  F.
 
-reset_timer(#fuse { timer_ref = none } = F) -> F;
-reset_timer(#fuse { timer_ref = TRef } = F) ->
-    _ = fuse_time:cancel_timer(TRef),
-    F#fuse { timer_ref = none }.
+reset_timer(#fuse{timer_ref = none} = F) ->
+  F;
+reset_timer(#fuse{timer_ref = TRef} = F) ->
+  _ = fuse_time:cancel_timer(TRef),
+  F#fuse{timer_ref = none}.
 
-install_metrics(#fuse { name = N }) ->
-    StatsPlugin = application:get_env(fuse, stats_plugin, fuse_stats_ets),
-    _ = StatsPlugin:init(N),
-    ok.
+install_metrics(#fuse{name = N}) ->
+  StatsPlugin = application:get_env(fuse, stats_plugin, fuse_stats_ets),
+  _ = StatsPlugin:init(N),
+  ok.

--- a/test/fuse_SUITE.erl
+++ b/test/fuse_SUITE.erl
@@ -1,4 +1,5 @@
 -module(fuse_SUITE).
+
 -include_lib("common_test/include/ct.hrl").
 
 -export([all/0]).
@@ -8,124 +9,164 @@
 -export([end_per_suite/1]).
 -export([init_per_group/2]).
 -export([end_per_group/2]).
-
 %% Tests.
--export([
-	simple_test/1,
-	reset_test/1,
-	remove_test/1
-]).
+-export([simple_test/1, simple_test_async_melt/1, reset_test/1, remove_test/1]).
 
 %% ct.
-all() -> [
-	simple_test,
-	reset_test,
-	remove_test
-].
+all() ->
+  [simple_test, simple_test_async_melt, reset_test, remove_test].
 
-groups() -> [].
+groups() ->
+  [].
 
 suite() ->
-	[{timetrap, {minutes, 2}}].
+  [{timetrap, {minutes, 2}}].
 
 init_per_suite(Config) ->
-	application:load(sasl),
-	application:set_env(sasl, sasl_error_logger, false),
-	application:set_env(sasl, errlog_type, error),
-	error_logger:tty(false),
-	ok = application:start(sasl),
-	{ok, _} = application:ensure_all_started(fuse),
-	Config.
+  application:load(sasl),
+  application:set_env(sasl, sasl_error_logger, false),
+  application:set_env(sasl, errlog_type, error),
+  error_logger:tty(false),
+  ok = application:start(sasl),
+  {ok, _} = application:ensure_all_started(fuse),
+  Config.
 
 end_per_suite(_Config) ->
-	application:stop(fuse),
-	application:stop(sasl),
-	ok.
+  application:stop(fuse),
+  application:stop(sasl),
+  ok.
 
 init_per_group(_Group, Config) ->
-	Config.
+  Config.
 
 end_per_group(_Group, _Config) ->
-	ok.
+  ok.
 
 %% Tests.
 
 -define(FUSE_SIMPLE, simple_fuse).
+
 simple_test(_Config) ->
-	ct:log("Install a new alarm handler to check alarms"),
-	ok = gen_event:swap_handler(alarm_handler, {alarm_handler, swap}, {my_ah, [self()]}),
+  ct:log("Install a new alarm handler to check alarms"),
+  ok = gen_event:swap_handler(alarm_handler, {alarm_handler, swap}, {my_ah, [self()]}),
 
-	ct:log("install a new event handler"),
-	ok = fuse_event:add_handler(my_eh, [self()]),
+  ct:log("install a new event handler"),
+  ok = fuse_event:add_handler(my_eh, [self()]),
 
-	ct:log("Set up a new fuse, melt it and then verify it resets correctly"),
-	ok = fuse:install(?FUSE_SIMPLE, {{standard, 2, 60}, {reset, 60*1000}}),
-	ok = fuse:ask(?FUSE_SIMPLE, sync),
-	ok = fuse:melt(?FUSE_SIMPLE),
-	ok = fuse:ask(?FUSE_SIMPLE, sync),
-	{ok, b} = fuse:run(?FUSE_SIMPLE, fun() -> {melt, b} end, sync),
-	{ok, a} = fuse:run(?FUSE_SIMPLE, fun() -> {ok, a} end, sync),
-	ok = fuse:melt(?FUSE_SIMPLE),
-	blown = fuse:ask(?FUSE_SIMPLE, sync),
-	receive
-		{?FUSE_SIMPLE, blown} -> ok
-	after 1000 ->
-	    ct:fail(timeout_eh)
-	end,
-	receive
-		{set_alarm, {?FUSE_SIMPLE, fuse_blown}} -> ok
-	after 61 * 1000 ->
-	    ct:fail(timeout_ah)
-	end,
-	ct:sleep(600),
-	ok = fuse:ask(?FUSE_SIMPLE, sync),
-	receive
-		{?FUSE_SIMPLE, ok} ->
-			ok
-	after 1000 ->
-		ct:fail(timeout_eh_2)
-	end,
-	ct:log("Removing the handler again"),
-	ok = fuse_event:delete_handler(my_eh, []),
-	ok.
+  ct:log("Set up a new fuse, melt it and then verify it resets correctly"),
+  ok = fuse:install(?FUSE_SIMPLE, {{standard, 2, 60}, {reset, 60 * 1000}}),
+  ok = fuse:ask(?FUSE_SIMPLE, sync),
+  ok = fuse:melt(?FUSE_SIMPLE),
+  ok = fuse:ask(?FUSE_SIMPLE, sync),
+  {ok, b} = fuse:run(?FUSE_SIMPLE, fun() -> {melt, b} end, sync),
+  {ok, a} = fuse:run(?FUSE_SIMPLE, fun() -> {ok, a} end, sync),
+  ok = fuse:melt(?FUSE_SIMPLE),
+  blown = fuse:ask(?FUSE_SIMPLE, sync),
+  receive
+    {?FUSE_SIMPLE, blown} ->
+      ok
+  after 1000 ->
+    ct:fail(timeout_eh)
+  end,
+  receive
+    {set_alarm, {?FUSE_SIMPLE, fuse_blown}} ->
+      ok
+  after 61 * 1000 ->
+    ct:fail(timeout_ah)
+  end,
+  ct:sleep(600),
+  ok = fuse:ask(?FUSE_SIMPLE, sync),
+  receive
+    {?FUSE_SIMPLE, ok} ->
+      ok
+  after 1000 ->
+    ct:fail(timeout_eh_2)
+  end,
+  ct:log("Removing the handler again"),
+  ok = fuse_event:delete_handler(my_eh, []),
+  ok.
+
+-define(FUSE_SIMPLE_ASYNC_MELT, simple_fuse_async_melt).
+
+simple_test_async_melt(_Config) ->
+  ct:log("Install a new alarm handler to check alarms"),
+  ok = gen_event:swap_handler(alarm_handler, {alarm_handler, swap}, {my_ah, [self()]}),
+
+  ct:log("install a new event handler"),
+  ok = fuse_event:add_handler(my_eh, [self()]),
+
+  ct:log("Set up a new fuse, melt it and then verify it resets correctly"),
+  ok = fuse:install(?FUSE_SIMPLE_ASYNC_MELT, {{standard, 2, 60}, {reset, 60 * 1000}}),
+  ok = fuse:ask(?FUSE_SIMPLE_ASYNC_MELT, sync),
+  ok = fuse:melt_async(?FUSE_SIMPLE_ASYNC_MELT),
+  ok = fuse:ask(?FUSE_SIMPLE_ASYNC_MELT, sync),
+  {ok, b} = fuse:run(?FUSE_SIMPLE_ASYNC_MELT, fun() -> {melt, b} end, sync),
+  {ok, a} = fuse:run(?FUSE_SIMPLE_ASYNC_MELT, fun() -> {ok, a} end, sync),
+  ok = fuse:melt_async(?FUSE_SIMPLE_ASYNC_MELT),
+  blown = fuse:ask(?FUSE_SIMPLE_ASYNC_MELT, sync),
+  receive
+    {?FUSE_SIMPLE_ASYNC_MELT, blown} ->
+      ok
+  after 1000 ->
+    ct:fail(timeout_eh)
+  end,
+  receive
+    {set_alarm, {?FUSE_SIMPLE_ASYNC_MELT, fuse_blown}} ->
+      ok
+  after 61 * 1000 ->
+    ct:fail(timeout_ah)
+  end,
+  ct:sleep(1000),
+  ok = fuse:ask(?FUSE_SIMPLE_ASYNC_MELT, sync),
+  receive
+    {?FUSE_SIMPLE_ASYNC_MELT, ok} ->
+      ok
+  after 1000 ->
+    ct:fail(timeout_eh_2)
+  end,
+  ct:log("Removing the handler again"),
+  ok = fuse_event:delete_handler(my_eh, []),
+  ok.
 
 -define(FUSE_RESET, reset_fuse).
+
 reset_test(_Config) ->
-	ct:log("Installing a fuse, then resetting it should clear out timers"),
-	ok = fuse:install(?FUSE_RESET, {{standard, 2, 60}, {reset, 5000}}),
-	ok = fuse:ask(?FUSE_RESET, sync),
-	ok = fuse:melt(?FUSE_RESET),
-	ok = fuse:melt(?FUSE_RESET),
-	ok = fuse:melt(?FUSE_RESET),
-	blown = fuse:ask(?FUSE_RESET, sync),
-	ok = fuse:reset(?FUSE_RESET),
-	ok = fuse:ask(?FUSE_RESET, sync),
-	Stats = fuse_stats_ets:counters(?FUSE_RESET),
-	3 = proplists:get_value(melt, Stats),
-	2 = proplists:get_value(ok, Stats),
-	1 = proplists:get_value(blown, Stats),
-	ok.
+  ct:log("Installing a fuse, then resetting it should clear out timers"),
+  ok = fuse:install(?FUSE_RESET, {{standard, 2, 60}, {reset, 5000}}),
+  ok = fuse:ask(?FUSE_RESET, sync),
+  ok = fuse:melt(?FUSE_RESET),
+  ok = fuse:melt(?FUSE_RESET),
+  ok = fuse:melt(?FUSE_RESET),
+  blown = fuse:ask(?FUSE_RESET, sync),
+  ok = fuse:reset(?FUSE_RESET),
+  ok = fuse:ask(?FUSE_RESET, sync),
+  Stats = fuse_stats_ets:counters(?FUSE_RESET),
+  3 = proplists:get_value(melt, Stats),
+  2 = proplists:get_value(ok, Stats),
+  1 = proplists:get_value(blown, Stats),
+  ok.
 
 -define(FUSE_REMOVE, remove_fuse).
+
 remove_test(_Config) ->
-	ct:log("Install a fuse, melt it, blow it, then remove it, then recreate it"),
-	ok = fuse:install(?FUSE_REMOVE, {{standard, 2, 60}, {reset, 5000}}),
-	ok = fuse:ask(?FUSE_REMOVE, sync),
-	ok = fuse:melt(?FUSE_REMOVE),
-	ok = fuse:melt(?FUSE_REMOVE),
-	ok = fuse:melt(?FUSE_REMOVE),
-	blown = fuse:ask(?FUSE_REMOVE, sync),
-	Stats = fuse_stats_ets:counters(?FUSE_REMOVE),
-	3 = proplists:get_value(melt, Stats),
-	1 = proplists:get_value(ok, Stats),
-	1 = proplists:get_value(blown, Stats),
-	ok = fuse:remove(?FUSE_REMOVE),
-	{error, not_found} = fuse:ask(?FUSE_REMOVE, sync),
-	{error, not_found} = fuse:remove(?FUSE_REMOVE),
-	ok = fuse:install(?FUSE_REMOVE, {{standard, 2, 60}, {reset, 5000}}),
-	ok = fuse:ask(?FUSE_REMOVE, sync),
-	Stats2 = fuse_stats_ets:counters(?FUSE_REMOVE),
-	0 = proplists:get_value(melt, Stats2),
-	1 = proplists:get_value(ok, Stats2),
-	0 = proplists:get_value(blown, Stats2),
-	ok.
+  ct:log("Install a fuse, melt it, blow it, then remove it, then recreate it"),
+  ok = fuse:install(?FUSE_REMOVE, {{standard, 2, 60}, {reset, 5000}}),
+  ok = fuse:ask(?FUSE_REMOVE, sync),
+  ok = fuse:melt(?FUSE_REMOVE),
+  ok = fuse:melt(?FUSE_REMOVE),
+  ok = fuse:melt(?FUSE_REMOVE),
+  blown = fuse:ask(?FUSE_REMOVE, sync),
+  Stats = fuse_stats_ets:counters(?FUSE_REMOVE),
+  3 = proplists:get_value(melt, Stats),
+  1 = proplists:get_value(ok, Stats),
+  1 = proplists:get_value(blown, Stats),
+  ok = fuse:remove(?FUSE_REMOVE),
+  {error, not_found} = fuse:ask(?FUSE_REMOVE, sync),
+  {error, not_found} = fuse:remove(?FUSE_REMOVE),
+  ok = fuse:install(?FUSE_REMOVE, {{standard, 2, 60}, {reset, 5000}}),
+  ok = fuse:ask(?FUSE_REMOVE, sync),
+  Stats2 = fuse_stats_ets:counters(?FUSE_REMOVE),
+  0 = proplists:get_value(melt, Stats2),
+  1 = proplists:get_value(ok, Stats2),
+  0 = proplists:get_value(blown, Stats2),
+  ok.


### PR DESCRIPTION
This function will cast to the fuse_server, rather than call. In a high throughput system, with high tolerance for failure, calls to melt will begin to timeout, blocking the caller. Blocking the caller for the 5s default genserver timeout can often make overload issues worse. At the same time, changing this to a cast could lead to the fuse_server message queue to pile up more quickly :/

Apologies for all of the formatting changes...